### PR TITLE
feat(repo): :sparkles: allow python3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
-    python_requires=">=3.8.0,<3.11",
+    python_requires=">=3.8.0,<=3.11",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR bump the `setup.py` to allow `>=3.8, <=3.11` instead of `>=3.8, <3.11` so one could use python 3.11. 

Also resolve #11