### PR TITLE
fix: Relax python_requires version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
-    python_requires=">=3.8.0,<=3.11",
+    python_requires=">=3.8.0",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -73,6 +73,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Application Frameworks",


### PR DESCRIPTION
Hi,

Currently this library can't be installed under any patch version of python 3.11, e.g., `3.11.4` due to how `python_requires` is configured.

This PR adjusts `python_requires` to specify a minimum python version of 3.8 but does not specify a maximum version. This is generally preferable for libraries unless it becomes known that an upper version limit needs to be set.

Example of the current behavior:

```
$ python3 -V && pip3 install -U terra-python
Python 3.11.4
ERROR: Ignored the following versions that require a different python version: 0.0.10 Requires-Python >=3.8.0,<=3.11; 0.0.3 Requires-Python >=3.8.0,<3.11; 0.0.4 Requires-Python >=3.8.0,<3.11; 0.0.5 Requires-Python >=3.8.0,<3.11; 0.0.6 Requires-Python >=3.8.0,<3.11; 0.0.7 Requires-Python >=3.8.0,<3.11; 0.0.8 Requires-Python >=3.8.0,<3.11; 0.0.9 Requires-Python >=3.8.0,<3.11
ERROR: Could not find a version that satisfies the requirement terra-python (from versions: none)
ERROR: No matching distribution found for terra-python
```